### PR TITLE
[rhel-base] lock to 7.4

### DIFF
--- a/rhel-base/Dockerfile
+++ b/rhel-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel:7.4
 
 MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
 


### PR DESCRIPTION
7.5 breaks several things:

* subscription manager can't run inside docker on linux
* brewkoji fails to use Kerberos

@unleashed can you check it fixes https://github.com/unleashed/rhel-container/issues/1 ?