### PR TITLE
Bypass subscription-manager on RHEL

### DIFF
--- a/rhel-base/Dockerfile
+++ b/rhel-base/Dockerfile
@@ -5,12 +5,15 @@ MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
 # Mandatory arguments are user and password for Red Hat subscription.
 ARG RHEL_SUB_USER
 ARG RHEL_SUB_PASSWD
+ARG ON_RHEL_HOST
 
-RUN (subscription-manager unregister || true) \
- && subscription-manager clean \
- && echo "Subscribing (takes a while)" \
- && subscription-manager register --auto-attach \
-    --username=${RHEL_SUB_USER} --password=${RHEL_SUB_PASSWD}
+RUN if [ "x$ON_RHEL_HOST" = "x" ] ; then \
+      (subscription-manager unregister || true) \
+        && subscription-manager clean \
+        && echo "Subscribing (takes a while)" \
+        && subscription-manager register --auto-attach \
+          --username=${RHEL_SUB_USER} --password=${RHEL_SUB_PASSWD} ; \
+    fi
 
 RUN RHEL_MAJOR=$(set -euo pipefail; cat /etc/redhat-release | \
       sed -E -e 's/.*release\s+([0-9]+).*/\1/') \

--- a/rhel-base/Makefile
+++ b/rhel-base/Makefile
@@ -24,6 +24,7 @@ build_image: info
 	docker build -t $(IMAGE_NAME) \
 		--build-arg RHEL_SUB_USER=$(RHEL_SUB_USER) \
 		--build-arg RHEL_SUB_PASSWD=$(RHEL_SUB_PASSWD) \
+		--build-arg ON_RHEL_HOST=$(ON_RHEL_HOST) \
 		$(PROJECT_PATH)
 
 .PHONY: run


### PR DESCRIPTION
On a RHEL Host we don't need to run the subscription-manager inside the container. (in fact, we shouldn't, as it fails anyway)

The `ON_RHEL_HOST` env var / docker build argument allows us to simply skip it.

Related to https://github.com/unleashed/rhel-container/issues/1 (fixes it for RHEL hosts).