### PR TITLE
Fixed password characters breaking script

### DIFF
--- a/rhel-base/Makefile
+++ b/rhel-base/Makefile
@@ -23,7 +23,7 @@ build:
 build_image: info
 	docker build -t $(IMAGE_NAME) \
 		--build-arg RHEL_SUB_USER=$(RHEL_SUB_USER) \
-		--build-arg RHEL_SUB_PASSWD=$(RHEL_SUB_PASSWD) \
+		--build-arg RHEL_SUB_PASSWD="$(RHEL_SUB_PASSWD)" \
 		--build-arg ON_RHEL_HOST=$(ON_RHEL_HOST) \
 		$(PROJECT_PATH)
 


### PR DESCRIPTION
Improper characters in a password (as in, valid for RHEL subscription itself, but not suitable for use in command-line) would cause the script to fail. Adding the quotes around the password adds some basic sanitization.