### PR TITLE
Add support for entitlements tar.gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Requirements:
 
   * Docker (any moderately recent release should be ok)
   * A [Red Hat Developers account](https://developers.redhat.com/) for building
-    the base RHEL image.
+    the base RHEL image, or any other RHEL subscription if you have one.
 
 > **Note**: the image you will be building should **NOT** be published, as it contains a subscription to your account.
+
+Please check the section about [build issues](#build-issues) should you find any
+problem with the build process.
 
 ### Red Hat Enterprise Linux
 
@@ -32,8 +35,8 @@ have to change the `FROM` line in the relevant Dockerfile.
 #### Building under RHEL
 
 Note that Red Hat's version of Docker incorporates patches to allow containers
-to reuse the host's subscription. This is not currently supported here, as the
-build process will require the RHSM credentials.
+to reuse the host's subscription. If this is the case and you wish to reuse them,
+invoke the build process with `ON_RHEL_HOST=1`.
 
 ### Software Collections Library
 
@@ -48,15 +51,35 @@ You can add the EPEL repo by specifying `EPEL_ENABLE=1` in the command above.
 
 ### Build issues
 
-The most usual problem is subscription-manager being unable to successfully
-register and subscribe to your RHSM account. Just try again and always keep an
-eye on your RHSM subscription status.
+#### Subscription Manager takes a long time to execute and ends up failing
+
+If you have lots of subscriptions the manager can take quite a while to run, and
+it could be the case you would even see it failing to subscribe and register to
+your RHSM account. Always keep an eye on your RHSM subscription status, and
+everything else being ok just try again, as sometimes it will take a few tries
+to make it work.
+
+#### Subscription Manager cannot execute inside a container
+
+Unfortunately in some instances the subscription manager will refuse to execute
+inside a container (most likely due to the Red Hat Docker fork detecting RHSM is
+being used). If this happens you should create a tarball (.tar.gz) of the
+contents of /etc/pki/entitlement and /etc/pki/consumer of a successfully
+subscribed and registered RHEL machine (you can do this with a RHEL ISO image
+and a VM).
+
+Once you have that tarball, you should place it in any subdirectory of
+`rhel-base` and invoke the build process setting the variable `ENTITLEMENTS` to
+_the relative path from rhel-base to the tarball file_. For example, if you placed
+the tarball `entitlements.tar.gz` under `rhel-base`, you'd invoke:
+
+> $ make ENTITLEMENTS=./entitlements.tar.gz build
 
 ## Deleting the image
 
 Keep in mind that your RHEL image will have a subscription. In addition to not
 sharing the image, removing the subscription is advised before deleting it,
-since not doing so will keep the registered host in RHSM.
+since not doing so will keep the registered host/container in RHSM.
 
 You have a convenience target for this task, `make implode`. This target will
 remove containers (losing whatever changes you had there) and the image once it

--- a/rhel-base/Dockerfile
+++ b/rhel-base/Dockerfile
@@ -5,15 +5,38 @@ MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
 # Mandatory arguments are user and password for Red Hat subscription.
 ARG RHEL_SUB_USER
 ARG RHEL_SUB_PASSWD
-ARG ON_RHEL_HOST
 
-RUN if [ "x$ON_RHEL_HOST" = "x" ] ; then \
-      (subscription-manager unregister || true) \
+# Optional arguments
+
+# If set to any non empty value, it will avoid trying any special handling of
+# subscriptions, as it will assume they will be injected into the image (as Red
+# Hat's Docker fork does) based on the current entitlements of the host.
+ARG ON_RHEL_HOST=
+
+# If set to any non empty value, and ON_RHEL_HOST is empty, it will extract the
+# referred to tarball file, which should include the Red Hat's entitlement keys
+# including the full path hierarchy (ie. will be extracted to /, and you can
+# usually find these under /etc/pki/{entitlement,consumer}). Note that this file
+# should live somewhere in the context where this image is being built in,
+# typically the same directory as this Dockerfile.
+ARG ENTITLEMENTS=
+
+# A one-arg COPY will just send the context over, so we can delete this dir
+# unconditionally later on.
+COPY ${ENTITLEMENTS} /tmp/entitlements/
+
+RUN if [ "x${ON_RHEL_HOST}" = "x" ] ; then \
+      if test "x${ENTITLEMENTS}" != "x"; then \
+        tar xvzf "/tmp/entitlements/$(basename ${ENTITLEMENTS})" -C /; \
+      else \
+        (subscription-manager unregister || true) \
         && subscription-manager clean \
         && echo "Subscribing (takes a while)" \
         && subscription-manager register --auto-attach \
           --username=${RHEL_SUB_USER} --password=${RHEL_SUB_PASSWD} ; \
-    fi
+      fi \
+    fi \
+ && rm -rf /tmp/entitlements
 
 RUN RHEL_MAJOR=$(set -euo pipefail; cat /etc/redhat-release | \
       sed -E -e 's/.*release\s+([0-9]+).*/\1/') \
@@ -23,6 +46,7 @@ RUN RHEL_MAJOR=$(set -euo pipefail; cat /etc/redhat-release | \
  && yum-config-manager --enable rhel-${RHEL_MAJOR}-server-rpms \
  && yum-config-manager --enable rhel-${RHEL_MAJOR}-server-optional-rpms \
  && yum-config-manager --enable rhel-${RHEL_MAJOR}-server-extras-rpms \
+ && yum-config-manager --save --setopt=\*.tsflags=nodocs \
  && echo "Installing base packages" \
  && INSTALL_PKGS="bsdtar \
     findutils \

--- a/rhel-base/Makefile
+++ b/rhel-base/Makefile
@@ -4,6 +4,14 @@ PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 IMAGE_NAME = rhel-base
 CONTAINER_NAME ?= $(IMAGE_NAME)-container
 
+ON_RHEL_HOST ?=
+# Ensure this variable, if used, points to a tar.gz file in the build context
+# directory (typically the directory where the Dockerfile lives) or
+# a subdirectory, and refers to it with a relative path from the build context
+# directory, ie. if it lives in $(PROJECT_PATH), which is the default build
+# context directory, then you'd set this to "./entitlements.tar.gz".
+ENTITLEMENTS ?=
+
 default: info
 
 .PHONY: info
@@ -11,6 +19,8 @@ info:
 	@echo -e "Variables you should care about:\n\n"\
 		"RHEL_SUB_USER   = $(RHEL_SUB_USER)\n"\
 		"RHEL_SUB_PASSWD = ...\n"\
+		"ON_RHEL_HOST    = $(ON_RHEL_HOST)\n" \
+		"ENTITLEMENTS    = $(ENTITLEMENTS)\n" \
 		"IMAGE_NAME      = $(IMAGE_NAME)\n" \
 		"CONTAINER_NAME  = $(CONTAINER_NAME)\n"
 
@@ -25,6 +35,8 @@ build_image: info
 		--build-arg RHEL_SUB_USER=$(RHEL_SUB_USER) \
 		--build-arg RHEL_SUB_PASSWD="$(RHEL_SUB_PASSWD)" \
 		--build-arg ON_RHEL_HOST=$(ON_RHEL_HOST) \
+		--build-arg ENTITLEMENTS=$(ENTITLEMENTS) \
+		$(DOCKER_BUILD_EXTRA_PARAMS) \
 		$(PROJECT_PATH)
 
 .PHONY: run


### PR DESCRIPTION
An alternative method to have the subscription entitlements in the generated image is to provide a tar.gz file with the contents of `/etc/pki/entitlement` and `/etc/pki/consumer` from a successfully subscribed & registered RHEL machine.

This fixes #1 for most cases, as in the worst case you can generate it once and use the entitlements until they expire, so we are going to close it.